### PR TITLE
Remove pypy compatibility code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ python:
 os:
   - linux
   
+before_script:
+  - pip install coverage
+  
 script: 
   - coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.5"
+  - "3.6"
+  
+os:
+  - linux
+  
+script: setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "pypy3"
+
   
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.5"
   - "3.6"
-
   
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "pypy3"
   
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ python:
 os:
   - linux
   
-script: setup.py test
+script: 
+  - coverage run setup.py test

--- a/gksolite/__main__.py
+++ b/gksolite/__main__.py
@@ -26,6 +26,13 @@ def board_help():
         )
 
 
+def random_pattern():
+    list_of_all_patterns = patterns.PATTERNS
+    chosen_pattern = random.choice(list_of_all_patterns)
+    print("choosen pattern: ",chosen_pattern) 
+    return chosen_pattern
+
+
 def load_board(board_name, *padding):
     if not board_name:
         board_help()
@@ -39,7 +46,7 @@ def load_board(board_name, *padding):
         else:
             direction, amount = pad[0], pad[1:]
             kwargs[cli_arg_map[direction]] = float(amount) if amount == 'inf' else int(amount)
-    board_literal = getattr(patterns, board_name, board_name)
+    board_literal = getattr(patterns, random_pattern(), board_name)
     raw_board = reader.read_literal(board_literal)
     return boards.PaddedBoard(raw_board, **kwargs)
 

--- a/gksolite/__main__.py
+++ b/gksolite/__main__.py
@@ -72,7 +72,7 @@ CLI.add_argument(
     '-c', '--class',
     dest='gol_class',
     help='GOL implementation',
-    default='gksol.sparse',
+    default='gksolite.sparse',
 )
 CLI_BOARD = CLI.add_argument_group('Board settings')
 CLI_BOARD.add_argument(

--- a/gksolite/gksolite_unittests/test_mixins.py
+++ b/gksolite/gksolite_unittests/test_mixins.py
@@ -1,7 +1,7 @@
 import unittest
-import gksol.patterns
-import gksol.boards
-import gksol.plain
+import gksolite.patterns
+import gksolite.boards
+import gksolite.plain
 import random
 
 
@@ -9,7 +9,7 @@ class Mixin(object):
     """Container class to shield Mixins from top level namespace where ``unittest`` would run them"""
     class GolMixin(unittest.TestCase):
         """Standard tests for the Game of Life board interface"""
-        gol_cls = gksol.plain.ListGol
+        gol_cls = gksolite.plain.ListGol
 
         @staticmethod
         def _gol_to_list(gol_board):
@@ -26,11 +26,11 @@ class Mixin(object):
                     self.assertIsInstance(self.gol_cls(board), self.gol_cls)
 
         def test_init_board(self):
-            """initialize with gksol.boards.PaddedBoard"""
-            for pattern_name in gksol.patterns.PATTERNS:
+            """initialize with gksolite.boards.PaddedBoard"""
+            for pattern_name in gksolite.patterns.PATTERNS:
                 for padding in ({}, {'top': 20}, {'left': 30}, {'top': 10, 'bottom': 12, 'left': 15, 'right': 37}):
-                    board = gksol.boards.PaddedBoard(
-                        getattr(gksol.patterns, pattern_name),
+                    board = gksolite.boards.PaddedBoard(
+                        getattr(gksolite.patterns, pattern_name),
                         **padding
                     )
                     self.assertIsInstance(self.gol_cls(board), self.gol_cls)

--- a/gksolite/gksolite_unittests/test_mixins.py
+++ b/gksolite/gksolite_unittests/test_mixins.py
@@ -1,7 +1,7 @@
 import unittest
-import gksol.patterns
-import gksol.boards
-import gksol.plain
+import gksolite.patterns
+import gksolite.boards
+import gksolite.plain
 import random
 
 
@@ -9,7 +9,7 @@ class Mixin(object):
     """Container class to shield Mixins from top level namespace where ``unittest`` would run them"""
     class GolMixin(unittest.TestCase):
         """Standard tests for the Game of Life board interface"""
-        gol_cls = gksol.plain.ListGol
+        gol_cls = gksolite.plain.ListGol
 
         @staticmethod
         def _gol_to_list(gol_board):
@@ -26,11 +26,11 @@ class Mixin(object):
                     self.assertIsInstance(self.gol_cls(board), self.gol_cls)
 
         def test_init_board(self):
-            """initialize with gksol.boards.PaddedBoard"""
-            for pattern_name in gksol.patterns.PATTERNS:
+            """initialize with gmksolite.boards.PaddedBoard"""
+            for pattern_name in gksolite.patterns.PATTERNS:
                 for padding in ({}, {'top': 20}, {'left': 30}, {'top': 10, 'bottom': 12, 'left': 15, 'right': 37}):
-                    board = gksol.boards.PaddedBoard(
-                        getattr(gksol.patterns, pattern_name),
+                    board = gksolite.boards.PaddedBoard(
+                        getattr(gksolite.patterns, pattern_name),
                         **padding
                     )
                     self.assertIsInstance(self.gol_cls(board), self.gol_cls)

--- a/gksolite/patterns.py
+++ b/gksolite/patterns.py
@@ -81,9 +81,17 @@ BASELINE = pad("""\
 ######## #####   ###      ####### #####
 """)
 
+HEART = pad("""\
+    #      #
+  #   #  #   #
+   #   #    #
+     #    #
+       #
+""")
+
 PATTERNS = [
     'BLOCK', 'BLINKER', 'BLINKER3', 'PULSAR', 'PENTADECATHLON', 'PINWHEEL', 'GLIDER', 'DIEHARD', 'GLIDER_GUN',
-    'PENTOMINO'
+    'PENTOMINO', 'HEART'
 ]
 
 __all__ = PATTERNS[:]

--- a/gksolite/render.py
+++ b/gksolite/render.py
@@ -1,5 +1,4 @@
 import sys
-import cpy2py
 import platform
 import atexit
 
@@ -77,51 +76,7 @@ class NativeMPLDisplay(object):
         pyplot.title(title)
         pyplot.imshow(content)
         pyplot.pause(0.000001)
-
-
-class CPyMPLDisplay(cpy2py.TwinObject):
-    """
-    Renderer for a Game of Life board or nested list for text terminals
-
-    :param height: the maximum height to display the board
-    :type height: int
-    :param width: the maximum width to display the board
-    :type width: int
-
-    This renderer requires :py:mod:`matplotlib` and :py:mod:`cpy2py`.
-    """
-    __twin_id__ = 'python3'
-
-    def __init__(self, height=640, width=640):
-        from matplotlib import pyplot
-        self.height = height
-        self.width = width
-        pyplot.draw()
-
-    @cpy2py.localmethod
-    def show(self, gol, title='<Title>'):
-        draw_height = min(self.height, gol.height)
-        draw_width = min(self.width, gol.width)
-        content = []
-        for line_idx in range(draw_height):
-            line = gol[line_idx]
-            content.append([line[row_idx] for row_idx in range(draw_width)])
-        self._show_mpl(content, title=title)
-
-    def _show_mpl(self, gol_array, title):
-        from matplotlib import pyplot
-        pyplot.clf()
-        pyplot.title(title)
-        pyplot.imshow(gol_array)
-        pyplot.pause(0.000001)
-
-if platform.python_implementation() == 'PyPy':
-    from cpy2py.ipyc import ipyc_socket
-    draw_twinterpreter = cpy2py.TwinMaster(CPyMPLDisplay.__twin_id__, ipyc=ipyc_socket.DuplexSocketIPyC)
-    draw_twinterpreter.start()
-    atexit.register(draw_twinterpreter.stop)
-    MPLDisplay = CPyMPLDisplay
-else:
-    MPLDisplay = NativeMPLDisplay
+        
+MPLDisplay = NativeMPLDisplay
 
 __all__ = ['TextDisplay', 'MPLDisplay', 'NullDisplay']


### PR DESCRIPTION
This change removes the ``cpy2py`` references required for compatibility with pypy. It is no longer in the dependencies of setup.py